### PR TITLE
27 Added Public API Endpoint for AI Image Generation Prompts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ Please, document here only changes visible to the client app.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.0] - 2026-02-17
+
+### [27 Added Public API Endpoint for AI Image Generation Prompts](https://github.com/mrbalov/pace/issues/27)
+
+### Added
+- New `/strava/activities/*/image-generator/prompt` endpoint for generating AI image prompts from activity signals without authentication
+- Base64-encoded signals support as query parameter for self-contained prompt generation
+- Netlify function handler for the new prompt generation endpoint
+- Signal validation and decoding with proper error responses for invalid inputs
+
 ## [2.0.0] - 2026-02-17
 
 ### [27 Improved Type Safety for Strava API Guardrails Validation](https://github.com/mrbalov/pace/issues/27)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pace",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Generates AI images based on Strava activity data.",
   "type": "module",
   "private": true,

--- a/packages/server/netlify.toml
+++ b/packages/server/netlify.toml
@@ -61,6 +61,12 @@ status = 200
 force = true
 
 [[redirects]]
+from = "/strava/activities/*/image-generator/prompt"
+to = "/.netlify/functions/strava-activity-image-generation-prompt/:splat"
+status = 200
+force = true
+
+[[redirects]]
 from = "/strava/activity/*"
 to = "/.netlify/functions/strava-activity/:splat"
 status = 200

--- a/packages/server/netlify/functions/strava-activity-image-generation-prompt.ts
+++ b/packages/server/netlify/functions/strava-activity-image-generation-prompt.ts
@@ -1,0 +1,2 @@
+import { stravaActivityImageGenerationPromptHandler } from '../../src/adapters/netlify';
+export { stravaActivityImageGenerationPromptHandler as handler };

--- a/packages/server/src/adapters/index.ts
+++ b/packages/server/src/adapters/index.ts
@@ -5,6 +5,8 @@ export {
   stravaLogoutHandler,
   stravaActivitiesHandler,
   stravaActivityHandler,
+  stravaActivitySignalsHandler,
+  stravaActivityImageGenerationPromptHandler,
   activityImageGeneratorHandler,
   type NetlifyEvent,
   type NetlifyResponse,

--- a/packages/server/src/adapters/netlify.ts
+++ b/packages/server/src/adapters/netlify.ts
@@ -12,6 +12,7 @@ import {
   stravaActivities,
   stravaActivity,
   stravaActivitySignals,
+  stravaActivityImageGenerationPrompt,
   activityImageGenerator,
 } from '../routes';
 import { getConfig } from '../config';
@@ -90,11 +91,13 @@ const normalizePath = (path: string): string => {
       'strava-activities': '/strava/activities',
       'strava-activity': '/strava/activity',
       'strava-activity-signals': '/strava/activities',
+      'strava-activity-image-generation-prompt': '/strava/activities',
     };
 
     // Map function names to path suffixes
     const suffixMap: Record<string, string> = {
       'strava-activity-signals': '/signals',
+      'strava-activity-image-generation-prompt': '/image-generator/prompt',
     };
 
     const baseRoute = routeMap[functionName] || path;
@@ -678,6 +681,65 @@ export const activityImageGeneratorHandler = async (
 ): Promise<NetlifyResponse> => {
   const result = await activityImageGeneratorSuccess(event).catch((error) =>
     activityImageGeneratorError(error),
+  );
+  return result;
+};
+
+/**
+ * Handles successful strava activity image generation prompt request.
+ *
+ * @param {NetlifyEvent} event - Netlify function event
+ * @returns {Promise<NetlifyResponse>} Netlify function response
+ * @internal
+ */
+const stravaActivityImageGenerationPromptSuccess = async (
+  event: NetlifyEvent,
+): Promise<NetlifyResponse> => {
+  // Handle OPTIONS preflight requests
+  if (event.httpMethod === 'OPTIONS') {
+    return handleOptionsRequest(event);
+  }
+
+  const config = getConfig();
+  const request = netlifyEventToRequest(event);
+  const response = await stravaActivityImageGenerationPrompt(request, config);
+  return await webResponseToNetlify(response);
+};
+
+/**
+ * Handles strava activity image generation prompt error.
+ *
+ * @param {unknown} error - Error object
+ * @returns {NetlifyResponse} Error response
+ * @internal
+ */
+const stravaActivityImageGenerationPromptError = (error: unknown): NetlifyResponse => {
+  console.error('Error in strava-activity-image-generation-prompt function:', error);
+  const allowedOrigin = getAllowedOrigin();
+  return {
+    statusCode: 500,
+    headers: {
+      'Content-Type': 'application/json',
+      'Access-Control-Allow-Origin': allowedOrigin,
+      'Access-Control-Allow-Credentials': 'true',
+      'Access-Control-Allow-Methods': 'GET, POST, OPTIONS, DELETE',
+      'Access-Control-Allow-Headers': 'Content-Type',
+    },
+    body: JSON.stringify({ error: 'Internal server error' }),
+  };
+};
+
+/**
+ * Netlify Function handler for /strava/activities/:id/image-generator/prompt endpoint.
+ *
+ * @param {NetlifyEvent} event - Netlify function event
+ * @returns {Promise<NetlifyResponse>} Netlify function response
+ */
+export const stravaActivityImageGenerationPromptHandler = async (
+  event: NetlifyEvent,
+): Promise<NetlifyResponse> => {
+  const result = await stravaActivityImageGenerationPromptSuccess(event).catch((error) =>
+    stravaActivityImageGenerationPromptError(error),
   );
   return result;
 };


### PR DESCRIPTION
# Changelog

## [2.1.0] - 2026-02-17

### [27 Added Public API Endpoint for AI Image Generation Prompts](https://github.com/mrbalov/pace/issues/27)

### Added
- New `/strava/activities/*/image-generator/prompt` endpoint for generating AI image prompts from activity signals without authentication
- Base64-encoded signals support as query parameter for self-contained prompt generation
- Netlify function handler for the new prompt generation endpoint
- Signal validation and decoding with proper error responses for invalid inputs