### PR TITLE
27 Fixed Netlify Adapter Routing for Activity Image Generator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ Please, document here only changes visible to the client app.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.2.1] - 2026-02-17
+
+### [27 Fixed Netlify Adapter Routing for Activity Image Generator](https://github.com/mrbalov/pace/issues/27)
+
+### Fixed
+- Netlify redirect pattern for activity image generator endpoint to correctly handle the `/strava/activities/*/image-generator` path structure
+- Missing route mappings in Netlify adapter for the `activity-image-generator` function to properly normalize request paths
+
 ## [2.2.0] - 2026-02-17
 
 ### [27 Added Custom Prompt Support for AI Image Generation](https://github.com/mrbalov/pace/issues/27)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pace",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "Generates AI images based on Strava activity data.",
   "type": "module",
   "private": true,

--- a/packages/server/netlify.toml
+++ b/packages/server/netlify.toml
@@ -73,7 +73,7 @@ status = 200
 force = true
 
 [[redirects]]
-from = "/activity-image-generator/*"
+from = "/strava/activities/*/image-generator"
 to = "/.netlify/functions/activity-image-generator/:splat"
 status = 200
 force = true

--- a/packages/server/src/adapters/netlify.ts
+++ b/packages/server/src/adapters/netlify.ts
@@ -92,12 +92,14 @@ const normalizePath = (path: string): string => {
       'strava-activity': '/strava/activity',
       'strava-activity-signals': '/strava/activities',
       'strava-activity-image-generation-prompt': '/strava/activities',
+      'activity-image-generator': '/strava/activities',
     };
 
     // Map function names to path suffixes
     const suffixMap: Record<string, string> = {
       'strava-activity-signals': '/signals',
       'strava-activity-image-generation-prompt': '/image-generator/prompt',
+      'activity-image-generator': '/image-generator',
     };
 
     const baseRoute = routeMap[functionName] || path;


### PR DESCRIPTION
# Changelog

## [2.2.1] - 2026-02-17

### [27 Fixed Netlify Adapter Routing for Activity Image Generator](https://github.com/mrbalov/pace/issues/27)

### Fixed
- Netlify redirect pattern for activity image generator endpoint to correctly handle the `/strava/activities/*/image-generator` path structure
- Missing route mappings in Netlify adapter for the `activity-image-generator` function to properly normalize request paths