### PR TITLE
22 UI Removed Next.js Server Overwrites

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,5 +1,6 @@
 {
   "recommendations": [
-    "esbenp.prettier-vscode"
+    "esbenp.prettier-vscode",
+    "ms-vscode.vscode-speech"
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,25 @@ Please, document here only changes visible to the client app.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.0.0] - 2026-02-20
+
+### [22 UI Removed Next.js Server Overwrites](https://github.com/mrbalov/pace/issues/22)
+
+### Changed
+- **BREAKING:** Removed Next.js proxy rewrites for API endpoints, UI now makes direct calls to backend server
+- **BREAKING:** Consolidated API URL configuration to use `NEXT_PUBLIC_API_URL` environment variable exclusively
+- Updated API client to use full backend URLs with fallback to `http://localhost:3000`
+- Updated Docker configurations to use `NEXT_PUBLIC_API_URL` instead of `API_URL` for consistency
+
+### Removed
+- Next.js rewrites configuration from `next.config.mjs` that proxied `/strava/*` requests
+- `API_URL` environment variable usage in Docker compose files
+
+### Technical Notes
+- Backend server must now have CORS configured to allow requests from UI origin
+- All API requests use explicit URLs instead of relying on proxy routing
+- Simplified deployment configuration with single environment variable for API URLs
+
 ## [4.0.0] - 2026-02-20
 
 ### [22 UI Architecture Migration: Vite → Next.js, GeistUI → shadcn/ui with Enhanced SSR](https://github.com/mrbalov/pace/issues/22)

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -38,8 +38,8 @@ services:
     environment:
       - NODE_ENV=development
       - HOSTNAME=0.0.0.0
-      # Routes /strava/* to backend via next.config.mjs rewrites
-      - API_URL=http://server-dev:3000
+      # Direct API calls to backend server
+      - NEXT_PUBLIC_API_URL=http://server-dev:3000
     depends_on:
       - server-dev
     networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,8 +40,8 @@ services:
       - NODE_ENV=production
       - PORT=3001
       - HOSTNAME=0.0.0.0
-      # Routes /strava/* and /activity-image-generator/* to internal backend
-      - API_URL=http://server:3000
+      # Direct API calls to backend server
+      - NEXT_PUBLIC_API_URL=http://server:3000
     networks:
       - torq-network
     healthcheck:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "torq",
-  "version": "4.0.0",
+  "version": "5.0.0",
   "description": "Generates AI images based on Strava activity data.",
   "type": "module",
   "private": true,

--- a/packages/ui/.env.example
+++ b/packages/ui/.env.example
@@ -1,6 +1,1 @@
-# Backend API URL used by Next.js server-side rewrites (not exposed to browser)
-# In development, next.config.mjs proxies /strava/* to http://localhost:3000 by default
-API_URL=http://localhost:3000
-
-# Exposed to the browser - only required if bypassing the Next.js rewrite proxy
-# NEXT_PUBLIC_API_URL=
+NEXT_PUBLIC_API_URL=http://localhost:3000

--- a/packages/ui/next.config.mjs
+++ b/packages/ui/next.config.mjs
@@ -8,20 +8,6 @@ const nextConfig = {
     '@torq/get-strava-activity-signals',
     '@torq/get-strava-activity-image-generation-prompt',
   ],
-  /**
-   * Proxy /strava/* and /activity-image-generator/* to backend server.
-   * @returns {Promise<import('next').Rewrite[]>} Array of rewrite rules.
-   */
-  async rewrites() {
-    const apiUrl = process.env.API_URL ?? 'http://localhost:3000';
-
-    return [
-      {
-        source: '/strava/:path*',
-        destination: `${apiUrl}/strava/:path*`,
-      },
-    ];
-  },
 };
 
 export default nextConfig;

--- a/packages/ui/src/api/client.ts
+++ b/packages/ui/src/api/client.ts
@@ -1,12 +1,9 @@
 /**
  * Base API client with cookie-based authentication.
  * Communicates with /packages/server backend.
- *
- * Requests to /strava/* are proxied to the backend via next.config.mjs rewrites.
- * NEXT_PUBLIC_API_URL is only needed when running without the Next.js server proxy.
  */
 
-const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL ?? '';
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:3000';
 
 /**
  * Custom error class for API request failures.


### PR DESCRIPTION
# Changelog

## [5.0.0] - 2026-02-20

### [22 UI Removed Next.js Server Overwrites](https://github.com/mrbalov/pace/issues/22)

### Changed
- **BREAKING:** Removed Next.js proxy rewrites for API endpoints, UI now makes direct calls to backend server
- **BREAKING:** Consolidated API URL configuration to use `NEXT_PUBLIC_API_URL` environment variable exclusively
- Updated API client to use full backend URLs with fallback to `http://localhost:3000`
- Updated Docker configurations to use `NEXT_PUBLIC_API_URL` instead of `API_URL` for consistency

### Removed
- Next.js rewrites configuration from `next.config.mjs` that proxied `/strava/*` requests
- `API_URL` environment variable usage in Docker compose files

### Technical Notes
- Backend server must now have CORS configured to allow requests from UI origin
- All API requests use explicit URLs instead of relying on proxy routing
- Simplified deployment configuration with single environment variable for API URLs