### PR TITLE
94 Add Strava Footer Button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ Please, document here only changes visible to the client app.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [6.3.0] - 2026-03-31
+
+### [94 Add Strava Footer Button](https://github.com/torqlab/torq/issues/94)
+
+### Added
+- Strava club button in footer linking to https://www.strava.com/clubs/torqlab
+  - Custom SVG icon component (StravaIcon) with minimalistic design
+  - Opens Strava club link in new browser tab
+  - Includes security attributes (noopener, noreferrer)
+  - Styled consistently with existing footer social icon buttons
+  - Full accessibility support with aria-label and title attributes
+
 ## [6.2.0] - 2026-03-31
 
 ### [0 Implement Implementation Phase Skill for OpenSpec Workflow](https://github.com/torqlab/torq/issues/0)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "torq",
-  "version": "6.2.0",
+  "version": "6.3.0",
   "description": "Generates AI images based on Strava activity data.",
   "type": "module",
   "private": true,

--- a/packages/ui/src/components/organisms/Footer/Copywrite.tsx
+++ b/packages/ui/src/components/organisms/Footer/Copywrite.tsx
@@ -1,6 +1,7 @@
 import { Github, Globe } from 'lucide-react';
 
 import { LINKS } from './constants';
+import StravaIcon from './StravaIcon';
 
 /**
  * Copywrite information.
@@ -31,6 +32,16 @@ const Copywrite = () => (
         className="inline-flex items-center justify-center h-8 w-8 rounded-md border border-input bg-background text-muted-foreground shadow-sm hover:bg-accent hover:text-accent-foreground transition-colors"
       >
         <Globe size={14} />
+      </a>
+      <a
+        href={LINKS.STRAVA_CLUB}
+        target="_blank"
+        rel="noopener noreferrer"
+        aria-label="Go to TORQ Strava Club"
+        title="Go to TORQ Strava Club"
+        className="inline-flex items-center justify-center h-8 w-8 rounded-md border border-input bg-background text-muted-foreground shadow-sm hover:bg-accent hover:text-accent-foreground transition-colors"
+      >
+        <StravaIcon />
       </a>
     </div>
   </div>

--- a/packages/ui/src/components/organisms/Footer/StravaIcon.tsx
+++ b/packages/ui/src/components/organisms/Footer/StravaIcon.tsx
@@ -1,0 +1,23 @@
+/**
+ * Strava icon component.
+ * @returns {JSX.Element} SVG icon for Strava.
+ */
+const StravaIcon = () => (
+  <svg
+    width="14"
+    height="14"
+    viewBox="0 0 192 192"
+    xmlns="http://www.w3.org/2000/svg"
+    fill="none"
+  >
+    <path
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth="12"
+      d="m41 106 42-84 42 84m-26 12 26 52 26-52"
+    />
+  </svg>
+);
+
+export default StravaIcon;

--- a/packages/ui/src/components/organisms/Footer/constants.ts
+++ b/packages/ui/src/components/organisms/Footer/constants.ts
@@ -1,6 +1,7 @@
 export const LINKS = {
   PROJECT_GITHUB: 'https://github.com/torqlab',
   AUTHOR_BLOG: 'https://balov.dev',
+  STRAVA_CLUB: 'https://www.strava.com/clubs/torqlab',
   POLLINATIONS_AI: 'https://pollinations.ai/',
   NETLIFY: 'https://www.netlify.com/',
 };


### PR DESCRIPTION
# Changelog

### [94 Add Strava Footer Button](https://github.com/torqlab/torq/issues/94)

### Added
- Strava club button in footer linking to https://www.strava.com/clubs/torqlab
  - Custom SVG icon component (StravaIcon) with minimalistic design
  - Opens Strava club link in new browser tab
  - Includes security attributes (noopener, noreferrer)
  - Styled consistently with existing footer social icon buttons
  - Full accessibility support with aria-label and title attributes